### PR TITLE
Mieux préciser le titre de la practice

### DIFF
--- a/chapters/BP_110_fr.md
+++ b/chapters/BP_110_fr.md
@@ -1,4 +1,4 @@
-## N'utiliser que des fichiers double opt-in
+## N'utiliser que de l'embasement d'emails en double opt-in
 
 ### Identifiants
 
@@ -39,4 +39,4 @@ Dans le cas d’un opérateur téléphonique ou d’une banque, laisser aux clie
 
 | Le nombre ...     | est inférieur ou égal à   |  
 |-------------------|:-------------------------:|
-|  de fichiers de contacts en opt-out | 0  |
+|  de fichiers d'email de contact en opt-out | 0  |


### PR DESCRIPTION
En lisant cette practice la première fois, je n'ai absolument pas compris ce dont il était question. 
La notion de fichier et d'email était confuse et pouvait laisser croire qu'on parlait de pièces jointes sans lire la suite.

Il me semble plus approprié de préciser qu'on parle d'embasement d'email. Des termes comme "prospect" ou "fichier client" iraient aussi, je pense.