### PR TITLE
Retirer la référence à Pressflow

### DIFF
--- a/chapters/BP_016_fr.md
+++ b/chapters/BP_016_fr.md
@@ -30,7 +30,6 @@ un périmètre fonctionnel et technique suffisant pour votre projet, vous devez 
 
 ### Exemple
 
- - À Drupal, préférer plutôt la version optimisée Pressflow.
  - À Redis, préférer plutôt la version optimisée KeyDB.
 
 ### Principe de validation


### PR DESCRIPTION
Ce fork était lié à Drupal 6 qui n'est plus maintenu, les modifications ont été ajoutées à Drupal cœur par la suite.
