### PR TITLE
2 corrections linguistiques mineures en français

### DIFF
--- a/chapters/BP_035_fr.md
+++ b/chapters/BP_035_fr.md
@@ -46,7 +46,7 @@ Cette image de 198 × 198 pixels pèse :
  - 3,8 Ko en PNG ;
  - 0,7 Ko en SVG minifié.
 
-Le format vectoriel est, dans ce cas précis, 5 à 10 fois moins lourd qu’un format matriciel tout en pouvant être retaillé à l’infini.
+Le format vectoriel est, dans ce cas précis, 5 à 10 fois moins lourd qu’un format matriciel tout en pouvant être redimensionné à l’infini.
 
 ### Principe de validation
 

--- a/chapters/BP_4003_fr.md
+++ b/chapters/BP_4003_fr.md
@@ -51,4 +51,4 @@ Audio :
 
 | Le nombre ... |     est inférieur ou égal à   |  
 |-------------------|:-------------------------:|
-| d'éléments `<video>` ou `<audio>` sans un attribut `preload="none"` ou `autoplay` | 0 |
+| d'éléments `<video>` ou `<audio>` sans un attribut `preload="none"` ou avec `autoplay` | 0 |


### PR DESCRIPTION
- `retaillé` → `redimensionné` (On retaille une haie ✂️)
- Clarification d'une phrase ambigüe. (Note : L'erreur semble aussi présente dans les autres langues)